### PR TITLE
shell.nix: prefer 'npm ci' to 'npm install'

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -15,6 +15,6 @@ pkgs.mkShell {
     export build="$project/.build"
     export PATH="$project/bin:$PATH"
 
-    npm install --loglevel error >/dev/null
+    npm ci --loglevel error >/dev/null
     '';
 }


### PR DESCRIPTION
'npm ci' seems more suited to this use case, since per 'npm help ci':

* If dependencies in the package lock do not match those in package.json, npm ci will exit with an error, instead of updating the package lock.

* It will never write to package.json or any of the package-locks: installs are essentially frozen.