### PR TITLE
fix: use correct path for data files in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ source of examples for all Elm developers.
 ## Submissions
 
 Simply submit a PR with your info added to the beginning of the array in
-`data/projects.json` and add a screenshot in `data/images`. Ensure that the
+`public/data/projects.json` and add a screenshot in `public/data/images`. Ensure that the
 screenshot is **1000px x 800px** and is **optimized** for the web. If your
 project is open source, please fill in your repository URL. Otherwise, just
 leave it as `null`.


### PR DESCRIPTION
Files are in the `public/data` directory, not directly in `data`.