### PR TITLE
Update Hangers repository URL

### DIFF
--- a/public/data/projects.json
+++ b/public/data/projects.json
@@ -67,7 +67,7 @@
     "description": "Hangers is a multiplayer game of words and wits. To win, you must guess every opponent's secret word before they guess yours. Battle opponents worldwide in the arena or play with friends in a private match.",
     "primaryUrl": "https://hangers.party",
     "previewImageUrl": "data/images/hangers.png",
-    "repositoryUrl": "https://github.com/jawnyawns/hangers"
+    "repositoryUrl": "https://github.com/johnchinjew/hangers"
   },
   {
     "name": "Elm Playground",


### PR DESCRIPTION
I recently changed my GitHub username from `jawnyawns` to `johnchinjew`. This PR updates the `repositoryUrl` for the Hangers project entry to use my updated username.